### PR TITLE
[SPR1-1248] Create structure and basic functionality.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+devinstall:
+	# Assume default Ansible Galaxy path
+	mkdir -p ~/.ansible/roles/katsdp-ansible-nomad-jobs
+	cp -ru * ~/.ansible/roles/katsdp-ansible-nomad-jobs/.
+
+install:
+	ansible-galaxy role install git+file://${PWD} --force

--- a/README.md
+++ b/README.md
@@ -17,14 +17,20 @@ Also, see [requirements.yml|examples/requirements.yml].
 ## Usage
 
 See [playbook.yml|examples/playbook.yml].
+The role is only applied once per execution, if multiple Ansible targets are given it will only be run on the first suitable target.
 
 ### Variables
 The following variables control the deployment. Job Sets have variables that can be set, see vars.yml in job set folders.
 
+* nomad_server_enabled: This variable control if the job can run on a system. Default to false.
+* *nomad_cluster_jobs_present: List of Job Sets to add to the cluster. Default to [].
+* **nomad_job_deployment_path: Temporary working directory on server. Default to '/opt/nomad/deploy'.
+* datacenter_name: The name of the Nomad datacenter. This field is used in the Nomad job specifications.
 
 ## Job Set
 A job set is the configuration files to deploy jobs to Nomad.
 A Job set consists out of different categories of files.
+Each Job Set is a directory in the templates directory of this repository.
 
 ### Nomad Job Set files
 Nomad job definition files as Ansible templates. These can be either HCL or JSON files.
@@ -40,3 +46,6 @@ All the variables from the vars.yml file will be keys in a 'job_vars' object.
 Files to be loaded into Consul Key-Value store. The value of the files will be available to Nomad jobs via Nomad-Consul templates or Nomad artefact requests.
 Files with the pattern `consul.*` are copied to a Job Set path in Consul Key-Value store. The consul prefix is stripped from the filename.
 Files with the pattern `consul.*.j2` are copied to a Job Set path in Consul Key-Value store after the file has been processed by Ansible template. The 'consul.' prefix and '.j2' suffix is stripped from the filename.
+
+## Requirements
+Nomad and Consul has to be installed and configured on the target server. At present the nomad and consul commands need to be in the PATH.

--- a/README.md
+++ b/README.md
@@ -6,26 +6,26 @@ This role is associated with https://github.com/ska-sa/katsdp-ansible-collection
 ## Installation
 
 Initially install by checking out the source and using make.
-``
+```
 git clone https://github.com/ska-sa/katsdp-ansible-nomad-jobs.git
 cd katsdp-ansible-nomad-jobs
 make install
-``
+```
 
-Also, see [requirements.yml|examples/requirements.yml].
+Also, see [requirements.yml](examples/requirements.yml).
 
 ## Usage
 
-See [playbook.yml|examples/playbook.yml].
+See [playbook.yml](examples/playbook.yml).
 The role is only applied once per execution, if multiple Ansible targets are given it will only be run on the first suitable target.
 
 ### Variables
 The following variables control the deployment. Job Sets have variables that can be set, see vars.yml in job set folders.
 
-* nomad_server_enabled: This variable control if the job can run on a system. Default to false.
-* *nomad_cluster_jobs_present: List of Job Sets to add to the cluster. Default to [].
-* **nomad_job_deployment_path: Temporary working directory on server. Default to '/opt/nomad/deploy'.
-* datacenter_name: The name of the Nomad datacenter. This field is used in the Nomad job specifications.
+* **nomad_server_enabled**: This variable control if the job can run on a system. Default to false.
+* **nomad_cluster_jobs_present**: List of Job Sets to add to the cluster. Default to [].
+* **nomad_job_deployment_path**: Temporary working directory on server. Default to '/opt/nomad/deploy'.
+* **datacenter_name**: The name of the Nomad datacenter. This field is used in the Nomad job specifications.
 
 ## Job Set
 A job set is the configuration files to deploy jobs to Nomad.
@@ -34,7 +34,7 @@ Each Job Set is a directory in the templates directory of this repository.
 
 ### Nomad Job Set files
 Nomad job definition files as Ansible templates. These can be either HCL or JSON files.
-The file must have the following pattern "nomad.****.hcl.j2" or "nomad.*.json.j2".
+The file must have the following pattern `nomad.*.hcl.j2` or `nomad.*.json.j2`.
 Each of these files will be loaded into Nomad. The command `nomad job run <filename>` will be called on each file.
 Typically there will be one Nomad template per Job Set.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,42 @@
 # katsdp-ansible-nomad-jobs
 Ansible role to deploy Nomad jobs
 
-This role is assosiated with https://github.com/ska-sa/katsdp-ansible-collection
+This role is associated with https://github.com/ska-sa/katsdp-ansible-collection
+
+## Installation
+
+Initially install by checking out the source and using make.
+``
+git clone https://github.com/ska-sa/katsdp-ansible-nomad-jobs.git
+cd katsdp-ansible-nomad-jobs
+make install
+``
+
+Also, see [requirements.yml|examples/requirements.yml].
+
+## Usage
+
+See [playbook.yml|examples/playbook.yml].
+
+### Variables
+The following variables control the deployment. Job Sets have variables that can be set, see vars.yml in job set folders.
+
+
+## Job Set
+A job set is the configuration files to deploy jobs to Nomad.
+A Job set consists out of different categories of files.
+
+### Nomad Job Set files
+Nomad job definition files as Ansible templates. These can be either HCL or JSON files.
+The file must have the following pattern "nomad.****.hcl.j2" or "nomad.*.json.j2".
+Each of these files will be loaded into Nomad. The command `nomad job run <filename>` will be called on each file.
+Typically there will be one Nomad template per Job Set.
+
+### Job Set variables file
+Each Job Set can have a vars.yml, the variables in this file will be loaded by the Ansible role and be available to templates.
+All the variables from the vars.yml file will be keys in a 'job_vars' object.
+
+### Consul Key-Value store records
+Files to be loaded into Consul Key-Value store. The value of the files will be available to Nomad jobs via Nomad-Consul templates or Nomad artefact requests.
+Files with the pattern `consul.*` are copied to a Job Set path in Consul Key-Value store. The consul prefix is stripped from the filename.
+Files with the pattern `consul.*.j2` are copied to a Job Set path in Consul Key-Value store after the file has been processed by Ansible template. The 'consul.' prefix and '.j2' suffix is stripped from the filename.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+nomad_cluster_jobs_present: []
+nomad_job_deployment_path: /opt/nomad/deploy

--- a/examples/host.yml
+++ b/examples/host.yml
@@ -1,0 +1,16 @@
+---
+
+# This file is the host definitian and should be placed in host_vars.
+
+ansible_host: server-name
+ansible_user: user
+ansible_ssh_pass: password
+ansible_sudo_pass: password
+datacenter_name: 'dc1'
+nomad_server_enabled: true
+nomad_client_enabled: false
+nomad_cluster_jobs_present:
+  - redis
+  - traefik
+  - prometheus
+  - elasticsearch

--- a/examples/playbook.yml
+++ b/examples/playbook.yml
@@ -1,0 +1,7 @@
+---
+
+# Ansible playbook to deploy nomad jobs.
+- hosts: all
+  become: yes
+  roles:
+    - katsdp-ansible-nomad-jobs

--- a/examples/requirements.yml
+++ b/examples/requirements.yml
@@ -1,0 +1,5 @@
+---
+
+roles:
+  - name: katsdp-ansible-nomad-jobs
+    src: https://github.com/ska-sa/katsdp-ansible-nomad-jobs.git

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  version: "0.1.0"
+  role_name: 'katsdp-ansible-nomad-jobs'
+  author: "Martin Slabber <mnartin@ska.ac.za>"
+  description: Templated Nomad Jobs
+  company: SARAO
+  license: BSD-3-Clause
+  min_ansible_version: 2.10
+  galaxy_tags: ['nomad', 'consul']
+dependencies: []

--- a/tasks/consul-kv.yml
+++ b/tasks/consul-kv.yml
@@ -1,0 +1,27 @@
+---
+# Copy or load a template into Consul K/V.
+
+- name: set short file name
+  set_fact:
+    short_file_name: "{{ file_name | basename | replace('consul.', '') | replace('.j2', '') }}"
+
+- name: set target file and Consul key
+  set_fact:
+    target_file: "{{ deploy_path.rstrip('/') }}/{{  short_file_name }}"
+    consul_kv_name: "{{ job_set }}/{{  short_file_name }}"
+    is_template: "{{ file_name.endswith('.j2') }}"
+
+- name: copy file
+  copy:
+    src: "{{ file_name }}"
+    dest: "{{ target_file }}"
+  when: not is_template
+
+- name: template file
+  template:
+    src: "{{ file_name }}"
+    dest: "{{ target_file }}"
+  when: is_template
+
+- name: load file into K/V value
+  command: "consul kv put {{ consul_kv_name }} @{{ target_file }}"

--- a/tasks/deploy-job.yml
+++ b/tasks/deploy-job.yml
@@ -1,0 +1,34 @@
+---
+
+# This is called for every job_set.
+- name: load default variables from file
+  include_vars:
+    file: "{{ item }}"
+    name: job_vars
+  with_fileglob:
+    - "templates/{{ job_set }}/vars.yml"
+
+- name: set local variables
+  set_fact:
+    deploy_path: "{{ nomad_job_deployment_path }}/{{ job_set }}/"
+
+- name: create deployment directory
+  ansible.builtin.file:
+    path: "{{ deploy_path }}"
+    state: directory
+    mode: '0755'
+    recurse: true
+
+- name: load files into Consul K/V store
+  include_tasks: consul-kv.yml
+  with_fileglob:
+    - "templates/{{ job_set }}/consul.*"
+  loop_control:
+    loop_var: file_name 
+
+- name: run Nomad job files
+  include_tasks: run-job.yml
+  with_fileglob:
+    - "templates/{{ job_set }}/nomad.*.j2" # Can be either hcl or json
+  loop_control:
+    loop_var: file_name 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- include_tasks: deploy-job.yml
+  run_once: true
+  # test that the node is a Nomad server
+  when: nomad_server_enabled is defined and nomad_server_enabled
+  loop: "{{ nomad_cluster_jobs_present }}"
+  loop_control:
+    loop_var: job_set

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - include_tasks: deploy-job.yml
   run_once: true
-  # test that the node is a Nomad server
+  # test if the node is a Nomad server
   when: nomad_server_enabled is defined and nomad_server_enabled
   loop: "{{ nomad_cluster_jobs_present }}"
   loop_control:

--- a/tasks/run-job.yml
+++ b/tasks/run-job.yml
@@ -13,5 +13,5 @@
 - name: load in nomad
   command: "nomad job run -detach {{ target_file }}"
   # Note: This is a fire and forget. No waiting for Nomad to prove and apply the
-  # Job since this can take a long time. Nomad apply duration deplens on the 
+  # Job since this can take a long time. Nomad apply duration depends on the
   # deployment options.

--- a/tasks/run-job.yml
+++ b/tasks/run-job.yml
@@ -1,0 +1,17 @@
+---
+# Template each of the nomad job files and call `nomad job run <file name>.hcl`.
+
+- name: set_fact
+  set_fact:
+    target_file: "{{ deploy_path.rstrip('/') }}/{{ file_name | basename | replace('.j2', '') }}"
+
+- name: template nomad job file
+  template:
+    src: "{{ file_name }}"
+    dest: "{{ target_file }}"
+
+- name: load in nomad
+  command: "nomad job run -detach {{ target_file }}"
+  # Note: This is a fire and forget. No waiting for Nomad to prove and apply the
+  # Job since this can take a long time. Nomad apply duration deplens on the 
+  # deployment options.


### PR DESCRIPTION
This is an Ansible role to deploy multiple job definitions to Nomad. Mostly useful for service and system jobs, batch jobs are best deployed from applications. We need to manage Nomad from Ansible in a simple way but still be able to enrich the Nomad jobs with Ansible variables.

This excludes Job Sets, which will be posted as separate PR's.


